### PR TITLE
Introduce UMD as a new output format

### DIFF
--- a/cmd/esbuild/main.go
+++ b/cmd/esbuild/main.go
@@ -28,8 +28,8 @@ var helpText = func(colors logger.Colors) string {
   --bundle              Bundle all dependencies into the output files
   --define:K=V          Substitute K with V while parsing
   --external:M          Exclude module M from the bundle (can use * wildcards)
-  --format=...          Output format (iife | cjs | esm, no default when not
-                        bundling, otherwise default is iife when platform
+  --format=...          Output format (iife | cjs | umd | esm, no default when
+		                    not bundling, otherwise default is iife when platform
                         is browser and cjs when platform is node)
   --loader:X=L          Use loader L to load file extension X, where L is
                         one of: js | jsx | ts | tsx | json | text | base64 |
@@ -53,7 +53,7 @@ var helpText = func(colors logger.Colors) string {
   --color=...               Force use of color terminal escapes (true | false)
   --error-limit=...         Maximum error count or 0 to disable (default 10)
   --footer=...              Text to be appended to each output file
-  --global-name=...         The name of the global for the IIFE format
+  --global-name=...         The name of the global for the IIFE or UMD formats
   --inject:F                Import the file F into all input files and
                             automatically replace matching globals with imports
   --jsx-factory=...         What to use for JSX instead of React.createElement

--- a/internal/bundler/bundler_default_test.go
+++ b/internal/bundler/bundler_default_test.go
@@ -237,6 +237,33 @@ func TestExportFormsIIFE(t *testing.T) {
 	})
 }
 
+func TestExportFormsUMD(t *testing.T) {
+	default_suite.expectBundled(t, bundled{
+		files: map[string]string{
+			"/entry.js": `
+				export default 123
+				export var v = 234
+				export let l = 234
+				export const c = 234
+				export {Class as C}
+				export function Fn() {}
+				export class Class {}
+				export * from './a'
+				export * as b from './b'
+			`,
+			"/a.js": "export const abc = undefined",
+			"/b.js": "export const xyz = null",
+		},
+		entryPaths: []string{"/entry.js"},
+		options: config.Options{
+			Mode:          config.ModeBundle,
+			OutputFormat:  config.FormatUMD,
+			GlobalName:    []string{"moduleName"},
+			AbsOutputFile: "/out.js",
+		},
+	})
+}
+
 func TestExportFormsWithMinifyIdentifiersAndNoBundle(t *testing.T) {
 	default_suite.expectBundled(t, bundled{
 		files: map[string]string{
@@ -2859,6 +2886,24 @@ func TestIIFE_ES5(t *testing.T) {
 	})
 }
 
+// The UMD should not be an arrow function when targeting ES5
+func TestUMD_ES5(t *testing.T) {
+	default_suite.expectBundled(t, bundled{
+		files: map[string]string{
+			"/entry.js": `
+				console.log('test');
+			`,
+		},
+		entryPaths: []string{"/entry.js"},
+		options: config.Options{
+			Mode:                  config.ModeBundle,
+			UnsupportedJSFeatures: es(5),
+			OutputFormat:          config.FormatUMD,
+			AbsOutputFile:         "/out.js",
+		},
+	})
+}
+
 func TestOutputExtensionRemappingFile(t *testing.T) {
 	default_suite.expectBundled(t, bundled{
 		files: map[string]string{
@@ -2978,6 +3023,26 @@ func TestTopLevelAwaitNoBundleIIFE(t *testing.T) {
 		},
 		expectedScanLog: `entry.js: error: Top-level await is currently not supported with the "iife" output format
 entry.js: error: Top-level await is currently not supported with the "iife" output format
+`,
+	})
+}
+
+func TestTopLevelAwaitNoBundleUMD(t *testing.T) {
+	default_suite.expectBundled(t, bundled{
+		files: map[string]string{
+			"/entry.js": `
+				await foo;
+				for await (foo of bar) ;
+			`,
+		},
+		entryPaths: []string{"/entry.js"},
+		options: config.Options{
+			OutputFormat:  config.FormatUMD,
+			Mode:          config.ModeConvertFormat,
+			AbsOutputFile: "/out.js",
+		},
+		expectedScanLog: `entry.js: error: Top-level await is currently not supported with the "umd" output format
+entry.js: error: Top-level await is currently not supported with the "umd" output format
 `,
 	})
 }

--- a/internal/bundler/bundler_loader_test.go
+++ b/internal/bundler/bundler_loader_test.go
@@ -380,6 +380,20 @@ func TestLoaderJSONNoBundleIIFE(t *testing.T) {
 	})
 }
 
+func TestLoaderJSONNoBundleUMD(t *testing.T) {
+	loader_suite.expectBundled(t, bundled{
+		files: map[string]string{
+			"/test.json": `{"test": 123, "invalid-identifier": true}`,
+		},
+		entryPaths: []string{"/test.json"},
+		options: config.Options{
+			Mode:          config.ModeConvertFormat,
+			OutputFormat:  config.FormatUMD,
+			AbsOutputFile: "/out.js",
+		},
+	})
+}
+
 func TestLoaderJSONSharedWithMultipleEntriesIssue413(t *testing.T) {
 	loader_suite.expectBundled(t, bundled{
 		files: map[string]string{

--- a/internal/bundler/linker.go
+++ b/internal/bundler/linker.go
@@ -466,7 +466,7 @@ func newLinkerContext(
 			// when the global name is present, since that's the only way the exports
 			// can actually be observed externally.
 			if repr.ast.HasES6Exports && (options.OutputFormat == config.FormatCommonJS ||
-				(options.OutputFormat == config.FormatIIFE && len(options.GlobalName) > 0)) {
+				((options.OutputFormat == config.FormatIIFE || options.OutputFormat == config.FormatUMD) && len(options.GlobalName) > 0)) {
 				repr.ast.UsesExportsRef = true
 				repr.meta.forceIncludeExportsForEntryPoint = true
 			}
@@ -1165,6 +1165,7 @@ func (c *linkerContext) scanImportsAndExports() {
 		// resulting wrapper won't be invoked by other files.
 		if repr.meta.cjsStyleExports &&
 			(c.options.OutputFormat == config.FormatIIFE ||
+				c.options.OutputFormat == config.FormatUMD ||
 				c.options.OutputFormat == config.FormatESModule) {
 			repr.meta.cjsWrap = true
 		}
@@ -1746,6 +1747,12 @@ func (c *linkerContext) createExportsForFile(sourceIndex uint32) {
 					}}}}
 				}
 
+			case config.FormatUMD:
+				// "return require_foo();"
+				cjsWrapStmt = js_ast.Stmt{Data: &js_ast.SReturn{Value: &js_ast.Expr{Data: &js_ast.ECall{
+					Target: js_ast.Expr{Data: &js_ast.EIdentifier{Ref: repr.ast.WrapperRef}},
+				}}}}
+
 			case config.FormatCommonJS:
 				// "module.exports = require_foo();"
 				cjsWrapStmt = js_ast.AssignStmt(
@@ -1764,7 +1771,9 @@ func (c *linkerContext) createExportsForFile(sourceIndex uint32) {
 					Target: js_ast.Expr{Data: &js_ast.EIdentifier{Ref: repr.ast.WrapperRef}},
 				}}}}}
 			}
-		} else if repr.meta.forceIncludeExportsForEntryPoint && c.options.OutputFormat == config.FormatIIFE && len(c.options.GlobalName) > 0 {
+		} else if repr.meta.forceIncludeExportsForEntryPoint &&
+			(c.options.OutputFormat == config.FormatIIFE ||
+				c.options.OutputFormat == config.FormatUMD) && len(c.options.GlobalName) > 0 {
 			// "return exports;"
 			cjsWrapStmt = js_ast.Stmt{Data: &js_ast.SReturn{Value: &js_ast.Expr{Data: &js_ast.EIdentifier{Ref: repr.ast.ExportsRef}}}}
 		}
@@ -3377,9 +3386,9 @@ func (c *linkerContext) generateCodeForFileInChunkJS(
 		lineOffsetTables = dataForSourceMaps[partRange.sourceIndex].lineOffsetTables
 	}
 
-	// Indent the file if everything is wrapped in an IIFE
+	// Indent the file if everything is wrapped in an IIFE or UMD
 	indent := 0
-	if c.options.OutputFormat == config.FormatIIFE {
+	if c.options.OutputFormat == config.FormatIIFE || c.options.OutputFormat == config.FormatUMD {
 		indent++
 	}
 
@@ -3636,9 +3645,9 @@ func (repr *chunkReprJS) generate(c *linkerContext, chunk *chunkInfo) func(gener
 		var crossChunkPrefix []byte
 		var crossChunkSuffix []byte
 		{
-			// Indent the file if everything is wrapped in an IIFE
+			// Indent the file if everything is wrapped in an IIFE or UMD
 			indent := 0
-			if c.options.OutputFormat == config.FormatIIFE {
+			if c.options.OutputFormat == config.FormatIIFE || c.options.OutputFormat == config.FormatUMD {
 				indent++
 			}
 			printOptions := js_printer.Options{
@@ -3715,9 +3724,41 @@ func (repr *chunkReprJS) generate(c *linkerContext, chunk *chunkInfo) func(gener
 			prevOffset.advanceString(text)
 			j.AddString(text)
 			newlineBeforeComment = false
+			// Optionally wrap with an UMD
+		} else if c.options.OutputFormat == config.FormatUMD {
+			var text string
+			var prefix string
+			indent = "  "
+			if len(c.options.GlobalName) > 0 {
+				prefix = generateModuleNameAssignment(c.options)
+			}
+			if c.options.UnsupportedJSFeatures.Has(compat.Arrow) {
+				text = "(function(root," + space + "factory)" + space + "{" + newline +
+					space + space + "if" + space + "(typeof define" + space + "===" + space + "\"function\"" + space + "&&" + space + "define.amd)" + space + "{" + newline +
+					space + space + space + space + "define(factory);" + newline +
+					space + space + "}" + space + "else if" + space + "(typeof module" + space + "===" + space + "\"object\"" + space + "&&" + space + "module.exports)" + space + "{" + newline +
+					space + space + space + space + "module.exports" + space + "=" + space + "factory();" + newline +
+					space + space + "}" + space + "else" + space + "{" + newline +
+					space + space + space + space + prefix + "factory();" + newline +
+					space + space + "}" + newline +
+					"}(typeof self" + space + "!==" + space + "\"undefined\"" + space + "?" + space + "self" + space + ":" + space + "this," + space + "function()" + space + "{" + newline
+			} else {
+				text = "(function(root," + space + "factory)" + space + "{" + newline +
+					space + space + "if" + space + "(typeof define" + space + "===" + space + "\"function\"" + space + "&&" + space + "define.amd)" + space + "{" + newline +
+					space + space + space + space + "define(factory);" + newline +
+					space + space + "}" + space + "else if" + space + "(typeof module" + space + "===" + space + "\"object\"" + space + "&&" + space + "module.exports)" + space + "{" + newline +
+					space + space + space + space + "module.exports" + space + "=" + space + "factory();" + newline +
+					space + space + "}" + space + "else" + space + "{" + newline +
+					space + space + space + space + prefix + "factory();" + newline +
+					space + space + "}" + newline +
+					"}(typeof self" + space + "!==" + space + "\"undefined\"" + space + "?" + space + "self" + space + ":" + space + "this," + space + "()" + space + "=>" + space + "{" + newline
+			}
+			prevOffset.advanceString(text)
+			j.AddString(text)
+			newlineBeforeComment = false
 		}
 
-		// Put the cross-chunk prefix inside the IIFE
+		// Put the cross-chunk prefix inside the IIFE or UMD
 		if len(crossChunkPrefix) > 0 {
 			newlineBeforeComment = true
 			prevOffset.advanceBytes(crossChunkPrefix)
@@ -3881,7 +3922,7 @@ func (repr *chunkReprJS) generate(c *linkerContext, chunk *chunkInfo) func(gener
 			j.AddBytes(entryPointTail.JS)
 		}
 
-		// Put the cross-chunk suffix inside the IIFE
+		// Put the cross-chunk suffix inside the IIFE or UMD
 		if len(crossChunkSuffix) > 0 {
 			if newlineBeforeComment {
 				j.AddString(newline)
@@ -3892,6 +3933,9 @@ func (repr *chunkReprJS) generate(c *linkerContext, chunk *chunkInfo) func(gener
 		// Optionally wrap with an IIFE
 		if c.options.OutputFormat == config.FormatIIFE {
 			j.AddString("})();" + newline)
+			// Optionally wrap with an UMD
+		} else if c.options.OutputFormat == config.FormatUMD {
+			j.AddString("}));" + newline)
 		}
 
 		// Make sure the file ends with a newline
@@ -4039,6 +4083,44 @@ func (c *linkerContext) generateGlobalNamePrefix() string {
 			prefix = fmt.Sprintf("%s[%s]", prefix, js_printer.QuoteForJSON(name, c.options.ASCIIOnly))
 		}
 		text += fmt.Sprintf("%s%s||%s{}%s%s%s=%s", oldPrefix, space, space, join, prefix, space, space)
+	}
+
+	return text
+}
+
+func generateModuleNameAssignment(options *config.Options) string {
+	var text string
+	prefix := options.GlobalName[0]
+	space := " "
+	join := ";\n"
+
+	if options.RemoveWhitespace {
+		space = ""
+		join = ";"
+	}
+
+	if js_printer.CanQuoteIdentifier(prefix, options.UnsupportedJSFeatures, options.ASCIIOnly) {
+		if options.ASCIIOnly {
+			prefix = string(js_printer.QuoteIdentifier(nil, prefix, options.UnsupportedJSFeatures))
+		}
+		prefix = "root." + prefix
+		text = fmt.Sprintf("%s%s=%s", prefix, space, space)
+	} else {
+		prefix = fmt.Sprintf("root[%s]", js_printer.QuoteForJSON(prefix, options.ASCIIOnly))
+		text = fmt.Sprintf("%s%s=%s", prefix, space, space)
+	}
+
+	for _, name := range options.GlobalName[1:] {
+		oldPrefix := prefix
+		if js_printer.CanQuoteIdentifier(name, options.UnsupportedJSFeatures, options.ASCIIOnly) {
+			if options.ASCIIOnly {
+				name = string(js_printer.QuoteIdentifier(nil, name, options.UnsupportedJSFeatures))
+			}
+			prefix = fmt.Sprintf("%s.%s", prefix, name)
+		} else {
+			prefix = fmt.Sprintf("%s[%s]", prefix, js_printer.QuoteForJSON(name, options.ASCIIOnly))
+		}
+		text += fmt.Sprintf("%s%s||%s{}%s%s%s%s%s%s%s=%s", oldPrefix, space, space, join, space, space, space, space, prefix, space, space)
 	}
 
 	return text

--- a/internal/bundler/snapshots/snapshots_default.txt
+++ b/internal/bundler/snapshots/snapshots_default.txt
@@ -670,6 +670,54 @@ var globalName = (() => {
 })();
 
 ================================================================================
+TestExportFormsUMD
+---------- /out.js ----------
+(function(root, factory) {
+  if (typeof define === "function" && define.amd) {
+    define(factory);
+  } else if (typeof module === "object" && module.exports) {
+    module.exports = factory();
+  } else {
+    root.moduleName = factory();
+  }
+}(typeof self !== "undefined" ? self : this, () => {
+  // entry.js
+  var entry_exports = {};
+  __export(entry_exports, {
+    C: () => Class,
+    Class: () => Class,
+    Fn: () => Fn,
+    abc: () => abc,
+    b: () => b_exports,
+    c: () => c,
+    default: () => entry_default,
+    l: () => l,
+    v: () => v
+  });
+
+  // a.js
+  var abc = void 0;
+
+  // b.js
+  var b_exports = {};
+  __export(b_exports, {
+    xyz: () => xyz
+  });
+  var xyz = null;
+
+  // entry.js
+  var entry_default = 123;
+  var v = 234;
+  var l = 234;
+  var c = 234;
+  function Fn() {
+  }
+  var Class = class {
+  };
+  return entry_exports;
+}));
+
+================================================================================
 TestExportFormsWithMinifyIdentifiersAndNoBundle
 ---------- /out/a.js ----------
 export default 123;
@@ -843,6 +891,22 @@ TestIIFE_ES5
   // entry.js
   console.log("test");
 })();
+
+================================================================================
+TestUMD_ES5
+---------- /out.js ----------
+(function(root, factory) {
+  if (typeof define === "function" && define.amd) {
+    define(factory);
+  } else if (typeof module === "object" && module.exports) {
+    module.exports = factory();
+  } else {
+    factory();
+  }
+}(typeof self !== "undefined" ? self : this, function() {
+  // entry.js
+  console.log("test");
+}));
 
 ================================================================================
 TestImportFSNodeCommonJS

--- a/internal/bundler/snapshots/snapshots_loader.txt
+++ b/internal/bundler/snapshots/snapshots_loader.txt
@@ -164,6 +164,24 @@ TestLoaderJSONNoBundleIIFE
 })();
 
 ================================================================================
+TestLoaderJSONNoBundleUMD
+---------- /out.js ----------
+(function(root, factory) {
+  if (typeof define === "function" && define.amd) {
+    define(factory);
+  } else if (typeof module === "object" && module.exports) {
+    module.exports = factory();
+  } else {
+    factory();
+  }
+}(typeof self !== "undefined" ? self : this, () => {
+  var require_test = __commonJS((exports, module) => {
+    module.exports = {test: 123, "invalid-identifier": true};
+  });
+  return require_test();
+}));
+
+================================================================================
 TestLoaderJSONSharedWithMultipleEntriesIssue413
 ---------- /out/a.js ----------
 // data.json

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -108,6 +108,21 @@ const (
 	//
 	FormatCommonJS
 
+	// The UMD format without external dependencies looks like this:
+	//
+	// (function(root, factory) {
+	//   if (typeof define === 'function' && define.amd) {
+	//     define(factory);
+	//   } else if (typeof module === 'object' && module.exports) {
+	//     module.exports = factory();
+	//   } else {
+	//     root.returnExports = factory();
+	//   }
+	// }(typeof self !== 'undefined' ? self : this, function() {
+	//   ... bundled code ...
+	// }));
+	FormatUMD
+
 	// The ES module format looks like this:
 	//
 	//   ... bundled code ...
@@ -126,6 +141,8 @@ func (f Format) String() string {
 		return "iife"
 	case FormatCommonJS:
 		return "cjs"
+	case FormatUMD:
+		return "umd"
 	case FormatESModule:
 		return "esm"
 	}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,5 +1,5 @@
 export type Platform = 'browser' | 'node' | 'neutral';
-export type Format = 'iife' | 'cjs' | 'esm';
+export type Format = 'iife' | 'cjs' | 'umd' | 'esm';
 export type Loader = 'js' | 'jsx' | 'ts' | 'tsx' | 'css' | 'json' | 'text' | 'base64' | 'file' | 'dataurl' | 'binary' | 'default';
 export type LogLevel = 'info' | 'warning' | 'error' | 'silent';
 export type Charset = 'ascii' | 'utf8';

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -139,6 +139,7 @@ const (
 	FormatDefault Format = iota
 	FormatIIFE
 	FormatCommonJS
+	FormatUMD
 	FormatESModule
 )
 

--- a/pkg/api/api_impl.go
+++ b/pkg/api/api_impl.go
@@ -51,6 +51,8 @@ func validateFormat(value Format) config.Format {
 		return config.FormatIIFE
 	case FormatCommonJS:
 		return config.FormatCommonJS
+	case FormatUMD:
+		return config.FormatUMD
 	case FormatESModule:
 		return config.FormatESModule
 	default:

--- a/pkg/cli/cli_impl.go
+++ b/pkg/cli/cli_impl.go
@@ -317,6 +317,12 @@ func parseOptionsImpl(osArgs []string, buildOpts *api.BuildOptions, transformOpt
 				} else {
 					transformOpts.Format = api.FormatCommonJS
 				}
+			case "umd":
+				if buildOpts != nil {
+					buildOpts.Format = api.FormatUMD
+				} else {
+					transformOpts.Format = api.FormatUMD
+				}
 			case "esm":
 				if buildOpts != nil {
 					buildOpts.Format = api.FormatESModule
@@ -324,7 +330,7 @@ func parseOptionsImpl(osArgs []string, buildOpts *api.BuildOptions, transformOpt
 					transformOpts.Format = api.FormatESModule
 				}
 			default:
-				return fmt.Errorf("Invalid format: %q (valid: iife, cjs, esm)", value)
+				return fmt.Errorf("Invalid format: %q (valid: iife, cjs, umd, esm)", value)
 			}
 
 		case strings.HasPrefix(arg, "--external:") && buildOpts != nil:

--- a/scripts/end-to-end-tests.js
+++ b/scripts/end-to-end-tests.js
@@ -2450,9 +2450,10 @@
     return async () => {
       const hasBundle = args.includes('--bundle')
       const hasIIFE = args.includes('--format=iife')
+      const hasUMD = args.includes('--format=umd')
       const hasCJS = args.includes('--format=cjs')
       const hasESM = args.includes('--format=esm')
-      const formats = hasIIFE ? ['iife'] : hasESM ? ['esm'] : hasCJS || !hasBundle ? ['cjs'] : ['cjs', 'esm']
+      const formats = hasIIFE ? ['iife'] : hasUMD ? ['umd'] : hasESM ? ['esm'] : hasCJS || !hasBundle ? ['cjs'] : ['cjs', 'esm']
       const expectedStderr = options && options.expectedStderr || '';
 
       // If the test doesn't specify a format, test both formats
@@ -2499,6 +2500,7 @@
           switch (format) {
             case 'cjs':
             case 'iife':
+            case 'umd':
               await fs.writeFile(path.join(thisTestDir, 'package.json'), '{"type": "commonjs"}')
               testExports = (await import(url.pathToFileURL(`${nodePath}.js`))).default
               break

--- a/scripts/js-api-tests.js
+++ b/scripts/js-api-tests.js
@@ -2521,6 +2521,35 @@ let transformTests = {
     if (out.fs.exists !== fs.exists) throw 'fail'
   },
 
+
+  async es6_import_to_umd({ service }) {
+    const { code } = await service.transform(`import {exists} from "fs"; if (!exists) throw 'fail'`, { format: 'umd' })
+    new Function('require', code)(require)
+  },
+
+  async es6_import_star_to_umd({ service }) {
+    const { code } = await service.transform(`import * as fs from "fs"; if (!fs.exists) throw 'fail'`, { format: 'umd' })
+    new Function('require', code)(require)
+  },
+
+  async es6_export_to_umd({ service }) {
+    const { code } = await service.transform(`export {exists} from "fs"`, { format: 'umd', globalName: 'out' })
+    const out = new Function('require', code + ';return this.out')(require)
+    if (out.exists !== fs.exists) throw 'fail'
+  },
+
+  async es6_export_star_to_umd({ service }) {
+    const { code } = await service.transform(`export * from "fs"`, { format: 'umd', globalName: 'out' })
+    const out = new Function('require', code + ';return this.out')(require)
+    if (out.exists !== fs.exists) throw 'fail'
+  },
+
+  async es6_export_star_as_to_umd({ service }) {
+    const { code } = await service.transform(`export * as fs from "fs"`, { format: 'umd', globalName: 'out' })
+    const out = new Function('require', code + ';return this.out')(require)
+    if (out.fs.exists !== fs.exists) throw 'fail'
+  },
+
   async es6_import_to_cjs({ service }) {
     const { code } = await service.transform(`import {exists} from "fs"; if (!exists) throw 'fail'`, { format: 'cjs' })
     new Function('require', code)(require)
@@ -2624,6 +2653,56 @@ let transformTests = {
 π["π 𐀀"] = π["π 𐀀"] || {};
 π["π 𐀀"].𐀀 = π["π 𐀀"].𐀀 || {};
 π["π 𐀀"].𐀀["𐀀 π"] = `)
+  },
+
+  async umdGlobalName({ service }) {
+    const { code } = await service.transform(`export default 123`, { format: 'umd', globalName: 'testName' })
+    const globals = {}
+    vm.createContext(globals)
+    vm.runInContext(code, globals)
+    assert.strictEqual(globals.testName.default, 123)
+  },
+
+  async umdGlobalNameCompound({ service }) {
+    const { code } = await service.transform(`export default 123`, { format: 'umd', globalName: 'test.name' })
+    const globals = {}
+    vm.createContext(globals)
+    vm.runInContext(code, globals)
+    assert.strictEqual(globals.test.name.default, 123)
+  },
+
+  async umdGlobalNameString({ service }) {
+    const { code } = await service.transform(`export default 123`, { format: 'umd', globalName: 'test["some text"]' })
+    const globals = {}
+    vm.createContext(globals)
+    vm.runInContext(code, globals)
+    assert.strictEqual(globals.test['some text'].default, 123)
+  },
+
+  async umdGlobalNameUnicodeEscape({ service }) {
+    const { code } = await service.transform(`export default 123`, { format: 'umd', globalName: 'π["π 𐀀"].𐀀["𐀀 π"]' })
+    const globals = {}
+    vm.createContext(globals)
+    vm.runInContext(code, globals)
+    assert.strictEqual(globals.π["π 𐀀"].𐀀["𐀀 π"].default, 123)
+    assert.strictEqual(code.slice(code.indexOf('} else {\n') + 9, code.indexOf('  }\n}(typeof')),
+      `    root.\\u03C0 = root.\\u03C0 || {};
+    root.\\u03C0["\\u03C0 \\uD800\\uDC00"] = root.\\u03C0["\\u03C0 \\uD800\\uDC00"] || {};
+    root.\\u03C0["\\u03C0 \\uD800\\uDC00"].\\u{10000} = root.\\u03C0["\\u03C0 \\uD800\\uDC00"].\\u{10000} || {};
+    root.\\u03C0["\\u03C0 \\uD800\\uDC00"].\\u{10000}["\\uD800\\uDC00 \\u03C0"] = factory();\n`)
+  },
+
+  async umdGlobalNameUnicodeNoEscape({ service }) {
+    const { code } = await service.transform(`export default 123`, { format: 'umd', globalName: 'π["π 𐀀"].𐀀["𐀀 π"]', charset: 'utf8' })
+    const globals = {}
+    vm.createContext(globals)
+    vm.runInContext(code, globals)
+    assert.strictEqual(globals.π["π 𐀀"].𐀀["𐀀 π"].default, 123)
+    assert.strictEqual(code.slice(code.indexOf('} else {\n') + 9, code.indexOf('  }\n}(typeof')),
+      `    root.π = root.π || {};
+    root.π["π 𐀀"] = root.π["π 𐀀"] || {};
+    root.π["π 𐀀"].𐀀 = root.π["π 𐀀"].𐀀 || {};
+    root.π["π 𐀀"].𐀀["𐀀 π"] = factory();\n`)
   },
 
   async jsx({ service }) {

--- a/scripts/try.html
+++ b/scripts/try.html
@@ -194,6 +194,7 @@
           <option selected>Preserve</option>
           <option>IIFE</option>
           <option>CJS</option>
+          <option>UMD</option>
           <option>ESM</option>
         </select>
       </label>


### PR DESCRIPTION
    --format=...  Output format (iife | cjs | umd | esm, no default
                  when not bundling, otherwise default is iife when
                  platform is browser and cjs when platform is node)

UMD format is similar to the IIFE format. Just the module wrapper and setting
the global variable differs. For example:

    // IIFE
    let moduleName = (() => {
      ... bundled code ...
      return exports;
    })();

    // UMD
    (function(root, factory) {
      if (typeof define === 'function' && define.amd) {
        define(factory);
      } else if (typeof module === 'object' && module.exports) {
        module.exports = factory();
      } else {
        root.moduleName = factory();
      }
    }(typeof self !== 'undefined' ? self : this, () => {
      ... bundled code ...
      return exports;
    }));

The module contents is generated with the help of the CJS wrapper, like IIFE.

This change supports only building of standalone applications or libraries. All
dependencies have to be included inside the output bundle or loaded by global
variables. Referring to external dependencies using AMD or CJS is not supported.